### PR TITLE
removed padding on ul

### DIFF
--- a/styles/module.css
+++ b/styles/module.css
@@ -14,7 +14,8 @@ nav ul{
   display: none;
   list-style-type: none;
   text-align: center;
-
+  margin: 0 auto;
+  padding: 0;
 }
 
 nav ul li {


### PR DESCRIPTION
There was a rule to remove the padding on the ul while being hovered on, but the same rule wasn't being applied to it while in default state.
